### PR TITLE
Removed unnecessary comparisons

### DIFF
--- a/lua/autorun/server/sv_alium_bans.lua
+++ b/lua/autorun/server/sv_alium_bans.lua
@@ -71,13 +71,13 @@ function AliumBanList:Get()
                     for line in stGmatch(body,"(.-)\n") do
                         line = stGsub(line, "\r","")
                         local st = stFind(line, "STEAM_0:", 0)
-                        if st != nil then
+                        if st then
                             AliumBanList["Bans"][toSteamID64(stSub(line, st, #line))] = true
                         end
                     end
                 end
             end,
-        }) != nil then
+        }) then
             self:Log("Списко банов от сообщества 'The Alium' успешно получен!")
         else
             self:Log("Возникла ошибка при получении списка банов!")
@@ -96,8 +96,8 @@ end)
 
 hook_Add("CheckPassword", "AliumBanList:CheckList", function(steamid64, ip, svPass, clPass, nick)
     local cfg = AliumBanList["cfg"]
-    if (AliumBanList["Bans"][steamid64] == true) then
-        if (cfg["printDisconnect"] == true) then
+    if (AliumBanList["Bans"][steamid64]) then
+        if (cfg["printDisconnect"]) then
             MsgC(cfg["colors"]["tagColor"], "["..cfg["tag"].."] ", cfg["colors"]["msgColor"], "Игрок, ", cfg["colors"]["nickColor"], nick, " ("..toSteamID(steamid64)..")", ", был заблокирован при попытке зайти на сервер!", "\n")
         end
 


### PR DESCRIPTION
Я, конечно, понимаю, что каждый дрочит как он хочет, и если мне мозолят глаза остутствия оступов между переменными и вызовами функций по типу
```lua
local cfg = AliumBanList["cfg"]
local col1 = cfg["colors"]["tagColor"]
local col2 = cfg["colors"]["msgColor"]
ply:SendLua('MsgC(Color('..col1["r"]..', '..col1["g"]..', '..col1["b"]..'), "['..cfg["tag"]..'] ", Color('..col2["r"]..', '..col2["g"]..', '..col2["b"]..'), "У вас недостаточно прав для выполнения данного действия!", "\n")')
```
Вместо
```lua
local cfg = AliumBanList["cfg"]

local col1 = cfg["colors"]["tagColor"]
local col2 = cfg["colors"]["msgColor"]

ply:SendLua('MsgC(Color('..col1["r"]..', '..col1["g"]..', '..col1["b"]..'), "['..cfg["tag"]..'] ", Color('..col2["r"]..', '..col2["g"]..', '..col2["b"]..'), "У вас недостаточно прав для выполнения данного действия!", "\n")')
```
То я это могу понять, дело вкуса. Но эти ваши сравнения ```!= nil``` и ```== true``` - полная ерунда. Хотя-бы потому, что зачем вы сишный синтаксис используете для операции not equal? Вы на Си подобных языках раньше писали?
И сами по себе эти проверки полная лажа, так как ```if(variable)``` и ```if(variable != nil)``` и ```if(variable == true)``` эквивалентны в случае, если не допускается, что variable может быть nil и не надо разделять false от nil (чего рекомендуется избегать хотя-бы по рекомендациям по codestyle от luarocks). Но в ваших случаях он не может быть nil.
Короче, я повыебывался, свой след оставил, а вы подумайте (вообще, это база, это знать надо). Спасибо за внимание и хорошего вам дня.